### PR TITLE
Add `spine` parsing in package file and `spine` command

### DIFF
--- a/epub_utils/cli.py
+++ b/epub_utils/cli.py
@@ -95,3 +95,13 @@ def metadata(ctx, format):
     doc = Document(ctx.obj['path'])
     package = doc.package
     output_document_part(package, 'metadata', format)
+
+
+@main.command()
+@format_option()
+@click.pass_context
+def spine(ctx, format):
+    """Outputs the spine information from the package file."""
+    doc = Document(ctx.obj['path'])
+    package = doc.package
+    output_document_part(package, 'spine', format)

--- a/epub_utils/package/__init__.py
+++ b/epub_utils/package/__init__.py
@@ -20,6 +20,7 @@ except ImportError:
 from epub_utils.exceptions import ParseError
 from epub_utils.highlighters import highlight_xml
 from epub_utils.package.metadata import Metadata
+from epub_utils.package.spine import Spine
 
 
 class Package:
@@ -95,13 +96,20 @@ class Package:
             self.version = root.attrib["version"]
             self.major_version = self.version.split(".", 1)[0]
 
+            # Parse metadata
             metadata_el = root.find(self.METADATA_XPATH)
             if metadata_el is None:
                 raise ValueError("Invalid OPF file: Missing metadata element.")
-            
-            metadata_xml_content = etree.tostring(metadata_el, encoding='unicode')
-            self.metadata = Metadata(metadata_xml_content)
+            metadata_xml = etree.tostring(metadata_el, encoding='unicode')
+            self.metadata = Metadata(metadata_xml)
 
+            # Parse spine
+            spine_el = root.find(self.SPINE_XPATH)
+            if spine_el is not None:
+                spine_xml = etree.tostring(spine_el, encoding='unicode')
+                self.spine = Spine(spine_xml)
+
+            # Parse TOC references
             if self.major_version == "3":
                 self.nav_href = self._find_nav_href(root)
             else:

--- a/epub_utils/package/spine.py
+++ b/epub_utils/package/spine.py
@@ -1,0 +1,57 @@
+try:
+    from lxml import etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+from epub_utils.exceptions import ParseError
+from epub_utils.highlighters import highlight_xml
+
+
+class Spine:
+    """
+    Represents the spine section of an EPUB package document.
+    The spine element defines the default reading order of the content.
+    """
+
+    def __init__(self, xml_content: str):
+        self.xml_content = xml_content
+        self.itemrefs = []
+        self.toc = None
+        self.page_progression_direction = None
+        self._parse(xml_content)
+
+    def __str__(self) -> str:
+        return self.xml_content
+
+    def to_str(self) -> str:
+        return str(self)
+
+    def to_xml(self, highlight_syntax=True) -> str:
+        return highlight_xml(self.xml_content)
+
+    def _parse(self, xml_content: str) -> None:
+        """
+        Parses the spine XML content.
+        """
+        try:
+            if isinstance(xml_content, str):
+                xml_content = xml_content.encode("utf-8")
+            root = etree.fromstring(xml_content)
+            
+            self.toc = root.get('toc')
+            self.page_progression_direction = root.get('page-progression-direction', 'default')
+            
+            for itemref in root.findall('.//itemref'):
+                idref = itemref.get('idref')
+                linear = itemref.get('linear', 'yes')
+                properties = itemref.get('properties', '').split()
+                
+                if idref:
+                    self.itemrefs.append({
+                        'idref': idref,
+                        'linear': linear == 'yes',
+                        'properties': properties
+                    })
+
+        except etree.ParseError as e:
+            raise ParseError(f"Error parsing spine element: {e}")

--- a/tests/test_spine.py
+++ b/tests/test_spine.py
@@ -1,0 +1,46 @@
+import pytest
+
+from epub_utils.package.spine import Spine
+from epub_utils.exceptions import ParseError
+
+VALID_SPINE_XML = """
+<spine toc="ncx" page-progression-direction="ltr">
+    <itemref idref="cover" linear="no"/>
+    <itemref idref="nav" linear="yes"/>
+    <itemref idref="chapter1" properties="page-spread-left"/>
+    <itemref idref="chapter2"/>
+</spine>
+"""
+
+MINIMAL_SPINE_XML = """
+<spine>
+    <itemref idref="content"/>
+</spine>
+"""
+
+def test_spine_initialization():
+    spine = Spine(VALID_SPINE_XML)
+    
+    assert spine.toc == "ncx"
+    assert spine.page_progression_direction == "ltr"
+    assert len(spine.itemrefs) == 4
+    
+    # Test first itemref (cover)
+    assert spine.itemrefs[0]["idref"] == "cover"
+    assert spine.itemrefs[0]["linear"] == False
+    assert spine.itemrefs[0]["properties"] == []
+    
+    # Test third itemref (chapter1)
+    assert spine.itemrefs[2]["idref"] == "chapter1"
+    assert spine.itemrefs[2]["linear"] == True
+    assert spine.itemrefs[2]["properties"] == ["page-spread-left"]
+
+def test_minimal_spine():
+    spine = Spine(MINIMAL_SPINE_XML)
+    
+    assert spine.toc is None
+    assert spine.page_progression_direction == "default"
+    assert len(spine.itemrefs) == 1
+    assert spine.itemrefs[0]["idref"] == "content"
+    assert spine.itemrefs[0]["linear"] == True
+    assert spine.itemrefs[0]["properties"] == []


### PR DESCRIPTION
This PR:
- Adds parsing of the `spine` element in the package OPF file
- Adds `spine` command to output spine information

#### References
- [EPUB 3.3: Package document - Spine section](https://www.w3.org/TR/epub/#sec-pkg-spine)