### PR TITLE
Fixing toc parsing for OEPBS 1

### DIFF
--- a/epub_utils/doc.py
+++ b/epub_utils/doc.py
@@ -80,12 +80,14 @@ class Document:
     def toc(self):
         if self._toc is None:
             package = self.package
-            if package.major_version == "3" and package.nav_href is not None:
+            if package.version.major == 3:
+                if not package.nav_href:
+                    return None
                 toc_href = package.nav_href
-            elif package.major_version == "2" and package.toc_href is not None:
-                toc_href = package.toc_href
             else:
-                return None
+                if not package.toc_href:
+                    return None
+                toc_href = package.toc_href
 
             toc_path = os.path.join(self.__package_href, toc_href)
             toc_xml_content = self._read_file_from_epub(toc_path)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -44,6 +44,21 @@ VALID_EPUB2_XML_WITHOUT_TOC = """<?xml version="1.0"?>
 </package>
 """
 
+VALID_OEPBS1_XML_WITH_TOC = """<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="1.0">
+<manifest><item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/></manifest>
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Sample EPUB</dc:title>
+</metadata>
+</package>
+"""
+
+INVALID_VERSION = """<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="4.0">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" />
+</package>
+"""
+
 
 def test_package_initialization():
     """
@@ -65,27 +80,39 @@ def test_package_invalid_xml():
 
 def test_epub3():
     package = Package(VALID_OPF_XML)
-    assert package.version == "3.0"
-    assert package.major_version == "3"
+    assert package.version.public == "3.0"
+    assert package.version.major == 3
     assert package.nav_href == "nav.xhtml"
 
 
 def test_epub3_without_toc():
     package = Package(VALID_EPUB3_XML_WITHOUT_TOC)
-    assert package.version == "3.0"
-    assert package.major_version == "3"
+    assert package.version.public == "3.0"
+    assert package.version.major == 3
     assert not package.nav_href
 
 
 def test_epub2():
     package = Package(VALID_EPUB2_XML)
-    assert package.version == "2.0"
-    assert package.major_version == "2"
+    assert package.version.public == "2.0"
+    assert package.version.major == 2
     assert package.toc_href == "toc.ncx"
 
 
 def test_epub2_without_toc():
     package = Package(VALID_EPUB2_XML_WITHOUT_TOC)
-    assert package.version == "2.0"
-    assert package.major_version == "2"
+    assert package.version.public == "2.0"
+    assert package.version.major == 2
     assert not package.toc_href
+
+
+def test_epub2():
+    package = Package(VALID_OEPBS1_XML_WITH_TOC)
+    assert package.version.public == "1.0"
+    assert package.version.major == 1
+    assert package.toc_href == "toc.ncx"
+
+
+def test_invalid_version():
+    with pytest.raises(ValueError, match="Unsupported epub version: 4"):
+        package = Package(INVALID_VERSION)


### PR DESCRIPTION
OEPBS 1 is the predecessor to EPUB(2) and is sometimes found in epub collections.
The TOC seems to work like for EPUB2 (ncx)

Using packaging.version instead of a inferior reimplementation.