### PR TITLE
Read from content plane

### DIFF
--- a/epub_utils/doc.py
+++ b/epub_utils/doc.py
@@ -97,6 +97,10 @@ class Document:
         return self._toc
 
     def find_content_by_id(self, item_id: str) -> str:
+        spine_item = self.package.spine.find_by_idref(item_id)
+        if not spine_item:
+            raise ValueError(f"Item id '{item_id}' not found in spine")
+        
         manifest_item = self.package.manifest.find_by_id(item_id)
         if not manifest_item:
             raise ValueError(f"Item ID '{item_id}' not found in manifest")

--- a/epub_utils/doc.py
+++ b/epub_utils/doc.py
@@ -103,7 +103,19 @@ class Document:
         
         manifest_item = self.package.manifest.find_by_id(item_id)
         if not manifest_item:
-            raise ValueError(f"Item ID '{item_id}' not found in manifest")
+            raise ValueError(f"Item id '{item_id}' not found in manifest")
+        
+        content_path = os.path.join(self.__package_href, manifest_item['href'])
+        xml_content = self._read_file_from_epub(content_path)
+
+        content = XHTMLContent(xml_content, manifest_item["media_type"], manifest_item["href"])
+
+        return content
+    
+    def find_pub_resource_by_id(self, item_id: str) -> str:
+        manifest_item = self.package.manifest.find_by_id(item_id)
+        if not manifest_item:
+            raise ValueError(f"Item id '{item_id}' not found in manifest")
         
         content_path = os.path.join(self.__package_href, manifest_item['href'])
         xml_content = self._read_file_from_epub(content_path)

--- a/epub_utils/package/spine.py
+++ b/epub_utils/package/spine.py
@@ -58,3 +58,10 @@ class Spine:
 
         except etree.ParseError as e:
             raise ParseError(f"Error parsing spine element: {e}")
+        
+    def find_by_idref(self, itemref_idref: str) -> dict:
+        """Find an itemref by its idref."""
+        for item in self.itemrefs:
+            if item['idref'] == itemref_idref:
+                return item
+        return None

--- a/epub_utils/package/spine.py
+++ b/epub_utils/package/spine.py
@@ -13,6 +13,9 @@ class Spine:
     The spine element defines the default reading order of the content.
     """
 
+    NAMESPACE = "http://www.idpf.org/2007/opf"
+    ITEMREF_XPATH = f".//{{{NAMESPACE}}}itemref"
+
     def __init__(self, xml_content: str):
         self.xml_content = xml_content
         self.itemrefs = []
@@ -41,7 +44,7 @@ class Spine:
             self.toc = root.get('toc')
             self.page_progression_direction = root.get('page-progression-direction', 'default')
             
-            for itemref in root.findall('.//itemref'):
+            for itemref in root.findall(self.ITEMREF_XPATH):
                 idref = itemref.get('idref')
                 linear = itemref.get('linear', 'yes')
                 properties = itemref.get('properties', '').split()

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,8 +1,8 @@
 import unittest
 
-from epub_utils.doc import Document
 from epub_utils.container import Container
-from epub_utils.package import Package, Manifest
+from epub_utils.doc import Document
+from epub_utils.package import Manifest, Package
 from epub_utils.toc import TableOfContents
 
 

--- a/tests/test_spine.py
+++ b/tests/test_spine.py
@@ -1,10 +1,7 @@
-import pytest
-
 from epub_utils.package.spine import Spine
-from epub_utils.exceptions import ParseError
 
 VALID_SPINE_XML = """
-<spine toc="ncx" page-progression-direction="ltr">
+<spine xmlns="http://www.idpf.org/2007/opf" toc="ncx" page-progression-direction="ltr">
     <itemref idref="cover" linear="no"/>
     <itemref idref="nav" linear="yes"/>
     <itemref idref="chapter1" properties="page-spread-left"/>
@@ -13,7 +10,7 @@ VALID_SPINE_XML = """
 """
 
 MINIMAL_SPINE_XML = """
-<spine>
+<spine xmlns="http://www.idpf.org/2007/opf">
     <itemref idref="content"/>
 </spine>
 """


### PR DESCRIPTION
This PR:
- Updates `Document.find_content_by_id` to find the item in the content plane in the Spine. The Spine element defines the content plane; so this method should only return items in the Spine