### PR TITLE
Add `--ncx` to force NCX toc retrieval

### DIFF
--- a/epub_utils/cli.py
+++ b/epub_utils/cli.py
@@ -155,11 +155,33 @@ def package(ctx, format, pretty_print):
 @main.command()
 @format_option()
 @pretty_print_option()
+@click.option(
+	'--ncx',
+	is_flag=True,
+	default=False,
+	help='Force retrieval of NCX file (EPUB 2 navigation control file).',
+)
+@click.option(
+	'--nav',
+	is_flag=True,
+	default=False,
+	help='Force retrieval of Navigation Document (EPUB 3 navigation file).',
+)
 @click.pass_context
-def toc(ctx, format, pretty_print):
+def toc(ctx, format, pretty_print, ncx, nav):
 	"""Outputs the Table of Contents (TOC) of the EPUB file."""
 	doc = Document(ctx.obj['path'])
-	output_document_part(doc, 'toc', format, pretty_print)
+
+	if ncx and nav:
+		click.secho('Error: --ncx and --nav flags cannot be used together.', fg='red', err=True)
+		ctx.exit(1)
+
+	if ncx:
+		part = 'ncx'
+	elif nav:
+		part = 'nav'
+
+	output_document_part(doc, part, format, pretty_print)
 
 
 @main.command()
@@ -240,7 +262,7 @@ def content(ctx, item_id, format, pretty_print):
 def files(ctx, file_path, format, pretty_print):
 	"""List all files in the EPUB archive with their metadata, or output content of a specific file."""
 	doc = Document(ctx.obj['path'])
-	
+
 	# Set dynamic default based on whether file_path is provided
 	if format is None:
 		format = 'xml' if file_path else 'table'

--- a/epub_utils/doc.py
+++ b/epub_utils/doc.py
@@ -97,6 +97,43 @@ class Document:
 
 		return self._toc
 
+	@property
+	def ncx(self):
+		package = self.package
+
+		if package.version.major < 3:
+			return self.toc
+
+		if not package.toc_href:
+			return None
+
+		toc_href = package.toc_href
+		toc_path = os.path.join(self.__package_href, toc_href)
+		toc_xml_content = self._read_file_from_epub(toc_path)
+
+		_ncx = TableOfContents(toc_xml_content)
+
+		return _ncx
+
+	@property
+	def nav(self):
+		"""Access the Navigation Document (EPUB 3) specifically."""
+		package = self.package
+
+		if package.version.major < 3:
+			return None
+
+		if not package.nav_href:
+			return None
+
+		nav_href = package.nav_href
+		nav_path = os.path.join(self.__package_href, nav_href)
+		nav_xml_content = self._read_file_from_epub(nav_path)
+
+		_nav = TableOfContents(nav_xml_content)
+
+		return _nav
+
 	def find_content_by_id(self, item_id: str) -> str:
 		spine_item = self.package.spine.find_by_idref(item_id)
 		if not spine_item:
@@ -203,5 +240,4 @@ class Document:
 
 			return XHTMLContent(file_content, media_type, file_path)
 		else:
-
 			return file_content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,24 @@ def test_files_command_without_file_path_raw(doc_path):
 	assert result.exit_code == 0
 	assert len(result.output) > 0
 	assert 'GoogleDoc/Roads.xhtml' in result.output
+
+
+def test_toc_command_default(doc_path):
+	"""Test the toc command with default behavior (auto-detect)."""
+	result = CliRunner().invoke(cli.main, [str(doc_path), 'toc'])
+	assert result.exit_code == 0
+	assert len(result.output) > 0
+
+
+def test_toc_command_nav_flag(doc_path):
+	"""Test the toc command with --nav flag."""
+	result = CliRunner().invoke(cli.main, [str(doc_path), 'toc', '--nav'])
+	assert result.exit_code == 0
+	assert len(result.output) > 0
+
+
+def test_toc_command_mutually_exclusive_flags(doc_path):
+	"""Test that --ncx and --nav flags are mutually exclusive."""
+	result = CliRunner().invoke(cli.main, [str(doc_path), 'toc', '--ncx', '--nav'])
+	assert result.exit_code == 1
+	assert '--ncx and --nav flags cannot be used together' in result.output

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -85,3 +85,14 @@ def test_document_get_file_by_path_missing_file(doc_path):
 		assert False, 'Expected ValueError for missing file'
 	except ValueError as e:
 		assert 'Missing' in str(e)
+
+
+def test_document_nav_property(doc_path):
+	"""
+	Test that the Document class correctly accesses the Navigation Document via nav property.
+	"""
+	doc = Document(doc_path)
+	nav = doc.nav
+
+	assert nav is not None
+	assert isinstance(nav, TableOfContents)


### PR DESCRIPTION
This PR:
- Adds a `--ncx` flag to the `toc` command to retrieve the table of contents from the NCX file, if available (#24). It also adds an equivalent `--nav` flag for the EPUB3 navigation file. The default behaviour is still to return the more recent navigafion file when available