### PR TITLE
Add NCX Document Object Model

### DIFF
--- a/epub_utils/navigation/base.py
+++ b/epub_utils/navigation/base.py
@@ -1,0 +1,12 @@
+class Navigation:
+	"""
+	Base class for Navigation Documents.
+
+	Attributes:
+	    media_type (str): The MIME type of the content.
+	    href (str): The path to the content file within the EPUB.
+	"""
+
+	def __init__(self, media_type: str, href: str) -> None:
+		self.media_type = media_type
+		self.href = href

--- a/epub_utils/navigation/ncx.py
+++ b/epub_utils/navigation/ncx.py
@@ -1,0 +1,76 @@
+import re
+
+from lxml import etree
+
+from epub_utils.exceptions import ParseError
+from epub_utils.navigation.base import Navigation
+from epub_utils.printers import XMLPrinter
+
+
+class NCXNavigation(Navigation):
+	MEDIA_TYPES = ['application/x-dtbncx+xml']
+
+	def __init__(self, xml_content: str, media_type: str, href: str) -> None:
+		self.xml_content = xml_content
+
+		self._tree = None
+
+		self.xmlns = None
+		self.version = None
+		self.lang = None
+
+		if media_type not in self.MEDIA_TYPES:
+			raise ValueError(f'Invalid media type for NCX navigation: {media_type}')
+		super().__init__(media_type, href)
+
+		self._parse(xml_content)
+
+		self._printer = XMLPrinter(self)
+
+	def __str__(self) -> str:
+		return self.xml_content
+
+	def to_str(self, *args, **kwargs) -> str:
+		return self._printer.to_str(*args, **kwargs)
+
+	def to_xml(self, *args, **kwargs) -> str:
+		return self._printer.to_xml(*args, **kwargs)
+
+	def to_plain(self) -> str:
+		return self.inner_text
+
+	def _parse(self, xml_content: str) -> None:
+		try:
+			self._tree = etree.fromstring(xml_content.encode('utf-8'))
+
+			root = self._tree
+
+			self.xmlns = root.nsmap.get(None, '') if root.nsmap else ''
+			self.version = root.get('version', '')
+			self.lang = root.get('{http://www.w3.org/XML/1998/namespace}lang', '')
+
+		except etree.ParseError as e:
+			raise ParseError(f'Error parsing Content file: {e}')
+
+	@property
+	def tree(self):
+		"""Lazily parse and cache the XHTML tree."""
+		if self._tree is None:
+			self._parse(self.xml_content)
+		return self._tree
+
+	@property
+	def inner_text(self) -> str:
+		tree = self.tree
+
+		body_elements = tree.xpath('//*[local-name()="body"]')
+
+		if body_elements:
+			inner_text = ''.join(body_elements[0].itertext())
+		else:
+			inner_text = ''.join(tree.itertext())
+
+		# Normalize whitespace
+		inner_text = re.sub(r'\s+', ' ', inner_text).strip()
+
+		return inner_text

--- a/epub_utils/navigation/ncx/__init__.py
+++ b/epub_utils/navigation/ncx/__init__.py
@@ -4,6 +4,7 @@ from lxml import etree
 
 from epub_utils.exceptions import ParseError
 from epub_utils.navigation.base import Navigation
+from epub_utils.navigation.ncx.dom import NCXDocument
 from epub_utils.printers import XMLPrinter
 
 
@@ -74,3 +75,8 @@ class NCXNavigation(Navigation):
 		inner_text = re.sub(r'\s+', ' ', inner_text).strip()
 
 		return inner_text
+
+	@property
+	def document(self) -> NCXDocument:
+		"""Get the NCX document root element."""
+		return NCXDocument(self.tree)

--- a/epub_utils/navigation/ncx/dom.py
+++ b/epub_utils/navigation/ncx/dom.py
@@ -1,0 +1,697 @@
+"""
+NCX DOM
+
+This module contains classes representing the DOM elements of NCX (Navigation Center eXtended) files.
+Based on the DAISY/NISO Standard, Section 8 of ANSI/NISO Z39.86-2005,
+Specifications for the Digital Talking Book.
+"""
+
+from typing import List, Optional, Union
+
+from lxml import etree
+
+
+class NCXElement:
+	"""Base class for all NCX elements."""
+
+	def __init__(self, element: etree.Element):
+		self.element = element
+		self.id = element.get('id')
+
+	@property
+	def tag(self) -> str:
+		"""Return the tag name without namespace."""
+		return etree.QName(self.element).localname
+
+	def get_attribute(self, name: str) -> Optional[str]:
+		"""Get an attribute value."""
+		return self.element.get(name)
+
+	def set_attribute(self, name: str, value: str) -> None:
+		"""Set an attribute value."""
+		self.element.set(name, value)
+
+
+class NCXText(NCXElement):
+	"""Represents a text element in NCX."""
+
+	@property
+	def text(self) -> str:
+		"""Get the text content."""
+		return self.element.text or ''
+
+	@text.setter
+	def text(self, value: str) -> None:
+		"""Set the text content."""
+		self.element.text = value
+
+
+class NCXContent(NCXElement):
+	"""Represents a content element that points to a resource."""
+
+	@property
+	def src(self) -> str:
+		"""Get the src attribute."""
+		return self.element.get('src', '')
+
+	@src.setter
+	def src(self, value: str) -> None:
+		"""Set the src attribute."""
+		self.element.set('src', value)
+
+
+class NCXMeta(NCXElement):
+	"""Represents a meta element in the NCX head."""
+
+	@property
+	def name(self) -> str:
+		"""Get the name attribute."""
+		return self.element.get('name', '')
+
+	@name.setter
+	def name(self, value: str) -> None:
+		"""Set the name attribute."""
+		self.element.set('name', value)
+
+	@property
+	def content(self) -> str:
+		"""Get the content attribute."""
+		return self.element.get('content', '')
+
+	@content.setter
+	def content(self, value: str) -> None:
+		"""Set the content attribute."""
+		self.element.set('content', value)
+
+
+class NCXHead(NCXElement):
+	"""Represents the head element containing metadata."""
+
+	@property
+	def metas(self) -> List[NCXMeta]:
+		"""Get all meta elements."""
+		meta_elements = self.element.xpath(
+			'.//ncx:meta', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXMeta(meta) for meta in meta_elements]
+
+	def get_meta(self, name: str) -> Optional[NCXMeta]:
+		"""Get a specific meta element by name."""
+		for meta in self.metas:
+			if meta.name == name:
+				return meta
+		return None
+
+	def add_meta(self, name: str, content: str) -> NCXMeta:
+		"""Add a new meta element."""
+		meta_element = etree.SubElement(self.element, 'meta')
+		meta = NCXMeta(meta_element)
+		meta.name = name
+		meta.content = content
+		return meta
+
+
+class NCXDocTitle(NCXElement):
+	"""Represents the docTitle element."""
+
+	@property
+	def text_element(self) -> Optional[NCXText]:
+		"""Get the text child element."""
+		text_elements = self.element.xpath(
+			'./ncx:text', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if text_elements:
+			return NCXText(text_elements[0])
+		return None
+
+	@property
+	def text(self) -> str:
+		"""Get the text content."""
+		text_elem = self.text_element
+		return text_elem.text if text_elem else ''
+
+	@text.setter
+	def text(self, value: str) -> None:
+		"""Set the text content."""
+		text_elem = self.text_element
+		if text_elem:
+			text_elem.text = value
+		else:
+			# Create text element if it doesn't exist
+			text_element = etree.SubElement(self.element, 'text')
+			text_elem = NCXText(text_element)
+			text_elem.text = value
+
+
+class NCXDocAuthor(NCXElement):
+	"""Represents the docAuthor element."""
+
+	@property
+	def text_element(self) -> Optional[NCXText]:
+		"""Get the text child element."""
+		text_elements = self.element.xpath(
+			'./ncx:text', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if text_elements:
+			return NCXText(text_elements[0])
+		return None
+
+	@property
+	def text(self) -> str:
+		"""Get the text content."""
+		text_elem = self.text_element
+		return text_elem.text if text_elem else ''
+
+	@text.setter
+	def text(self, value: str) -> None:
+		"""Set the text content."""
+		text_elem = self.text_element
+		if text_elem:
+			text_elem.text = value
+		else:
+			# Create text element if it doesn't exist
+			text_element = etree.SubElement(self.element, 'text')
+			text_elem = NCXText(text_element)
+			text_elem.text = value
+
+
+class NCXNavLabel(NCXElement):
+	"""Represents a navLabel element."""
+
+	@property
+	def text_element(self) -> Optional[NCXText]:
+		"""Get the text child element."""
+		text_elements = self.element.xpath(
+			'./ncx:text', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if text_elements:
+			return NCXText(text_elements[0])
+		return None
+
+	@property
+	def text(self) -> str:
+		"""Get the text content."""
+		text_elem = self.text_element
+		return text_elem.text if text_elem else ''
+
+	@text.setter
+	def text(self, value: str) -> None:
+		"""Set the text content."""
+		text_elem = self.text_element
+		if text_elem:
+			text_elem.text = value
+		else:
+			# Create text element if it doesn't exist
+			text_element = etree.SubElement(self.element, 'text')
+			text_elem = NCXText(text_element)
+			text_elem.text = value
+
+
+class NCXNavPoint(NCXElement):
+	"""Represents a navPoint element in the navigation hierarchy."""
+
+	@property
+	def class_attr(self) -> Optional[str]:
+		"""Get the class attribute."""
+		return self.element.get('class')
+
+	@class_attr.setter
+	def class_attr(self, value: str) -> None:
+		"""Set the class attribute."""
+		self.element.set('class', value)
+
+	@property
+	def play_order(self) -> Optional[int]:
+		"""Get the playOrder attribute."""
+		play_order = self.element.get('playOrder')
+		return int(play_order) if play_order else None
+
+	@play_order.setter
+	def play_order(self, value: int) -> None:
+		"""Set the playOrder attribute."""
+		self.element.set('playOrder', str(value))
+
+	@property
+	def nav_label(self) -> Optional[NCXNavLabel]:
+		"""Get the navLabel child element."""
+		nav_labels = self.element.xpath(
+			'./ncx:navLabel', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if nav_labels:
+			return NCXNavLabel(nav_labels[0])
+		return None
+
+	@property
+	def content(self) -> Optional[NCXContent]:
+		"""Get the content child element."""
+		content_elements = self.element.xpath(
+			'./ncx:content', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if content_elements:
+			return NCXContent(content_elements[0])
+		return None
+
+	@property
+	def nav_points(self) -> List['NCXNavPoint']:
+		"""Get child navPoint elements."""
+		nav_point_elements = self.element.xpath(
+			'./ncx:navPoint', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXNavPoint(point) for point in nav_point_elements]
+
+	def add_nav_point(
+		self,
+		id: str,
+		label_text: str,
+		src: str,
+		class_attr: Optional[str] = None,
+		play_order: Optional[int] = None,
+	) -> 'NCXNavPoint':
+		"""Add a child navPoint element."""
+		nav_point_element = etree.SubElement(self.element, 'navPoint')
+		nav_point = NCXNavPoint(nav_point_element)
+		nav_point.id = id
+
+		if class_attr:
+			nav_point.class_attr = class_attr
+		if play_order is not None:
+			nav_point.play_order = play_order
+
+		# Add navLabel
+		nav_label_element = etree.SubElement(nav_point_element, 'navLabel')
+		nav_label = NCXNavLabel(nav_label_element)
+		nav_label.text = label_text
+
+		# Add content
+		content_element = etree.SubElement(nav_point_element, 'content')
+		content = NCXContent(content_element)
+		content.src = src
+
+		return nav_point
+
+	@property
+	def label_text(self) -> str:
+		"""Get the text of the navLabel."""
+		nav_label = self.nav_label
+		return nav_label.text if nav_label else ''
+
+	@property
+	def content_src(self) -> str:
+		"""Get the src of the content element."""
+		content = self.content
+		return content.src if content else ''
+
+
+class NCXNavMap(NCXElement):
+	"""Represents the navMap element."""
+
+	@property
+	def nav_points(self) -> List[NCXNavPoint]:
+		"""Get all direct child navPoint elements."""
+		nav_point_elements = self.element.xpath(
+			'./ncx:navPoint', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXNavPoint(point) for point in nav_point_elements]
+
+	def add_nav_point(
+		self,
+		id: str,
+		label_text: str,
+		src: str,
+		class_attr: Optional[str] = None,
+		play_order: Optional[int] = None,
+	) -> NCXNavPoint:
+		"""Add a navPoint element."""
+		nav_point_element = etree.SubElement(self.element, 'navPoint')
+		nav_point = NCXNavPoint(nav_point_element)
+		nav_point.id = id
+
+		if class_attr:
+			nav_point.class_attr = class_attr
+		if play_order is not None:
+			nav_point.play_order = play_order
+
+		# Add navLabel
+		nav_label_element = etree.SubElement(nav_point_element, 'navLabel')
+		nav_label = NCXNavLabel(nav_label_element)
+		nav_label.text = label_text
+
+		# Add content
+		content_element = etree.SubElement(nav_point_element, 'content')
+		content = NCXContent(content_element)
+		content.src = src
+
+		return nav_point
+
+	def get_all_nav_points(self) -> List[NCXNavPoint]:
+		"""Get all navPoint elements recursively."""
+		nav_point_elements = self.element.xpath(
+			'.//ncx:navPoint', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXNavPoint(point) for point in nav_point_elements]
+
+
+class NCXPageTarget(NCXElement):
+	"""Represents a pageTarget element."""
+
+	@property
+	def type_attr(self) -> Optional[str]:
+		"""Get the type attribute."""
+		return self.element.get('type')
+
+	@type_attr.setter
+	def type_attr(self, value: str) -> None:
+		"""Set the type attribute."""
+		self.element.set('type', value)
+
+	@property
+	def value(self) -> Optional[str]:
+		"""Get the value attribute."""
+		return self.element.get('value')
+
+	@value.setter
+	def value(self, value: str) -> None:
+		"""Set the value attribute."""
+		self.element.set('value', value)
+
+	@property
+	def play_order(self) -> Optional[int]:
+		"""Get the playOrder attribute."""
+		play_order = self.element.get('playOrder')
+		return int(play_order) if play_order else None
+
+	@play_order.setter
+	def play_order(self, value: int) -> None:
+		"""Set the playOrder attribute."""
+		self.element.set('playOrder', str(value))
+
+	@property
+	def nav_label(self) -> Optional[NCXNavLabel]:
+		"""Get the navLabel child element."""
+		nav_labels = self.element.xpath(
+			'./ncx:navLabel', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if nav_labels:
+			return NCXNavLabel(nav_labels[0])
+		return None
+
+	@property
+	def content(self) -> Optional[NCXContent]:
+		"""Get the content child element."""
+		content_elements = self.element.xpath(
+			'./ncx:content', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if content_elements:
+			return NCXContent(content_elements[0])
+		return None
+
+	@property
+	def label_text(self) -> str:
+		"""Get the text of the navLabel."""
+		nav_label = self.nav_label
+		return nav_label.text if nav_label else ''
+
+	@property
+	def content_src(self) -> str:
+		"""Get the src of the content element."""
+		content = self.content
+		return content.src if content else ''
+
+
+class NCXPageList(NCXElement):
+	"""Represents the pageList element."""
+
+	@property
+	def page_targets(self) -> List[NCXPageTarget]:
+		"""Get all pageTarget elements."""
+		page_target_elements = self.element.xpath(
+			'./ncx:pageTarget', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXPageTarget(target) for target in page_target_elements]
+
+	def add_page_target(
+		self,
+		id: str,
+		type_attr: str,
+		value: str,
+		label_text: str,
+		src: str,
+		play_order: Optional[int] = None,
+	) -> NCXPageTarget:
+		"""Add a pageTarget element."""
+		page_target_element = etree.SubElement(self.element, 'pageTarget')
+		page_target = NCXPageTarget(page_target_element)
+		page_target.id = id
+		page_target.type_attr = type_attr
+		page_target.value = value
+
+		if play_order is not None:
+			page_target.play_order = play_order
+
+		# Add navLabel
+		nav_label_element = etree.SubElement(page_target_element, 'navLabel')
+		nav_label = NCXNavLabel(nav_label_element)
+		nav_label.text = label_text
+
+		# Add content
+		content_element = etree.SubElement(page_target_element, 'content')
+		content = NCXContent(content_element)
+		content.src = src
+
+		return page_target
+
+
+class NCXNavTarget(NCXElement):
+	"""Represents a navTarget element."""
+
+	@property
+	def play_order(self) -> Optional[int]:
+		"""Get the playOrder attribute."""
+		play_order = self.element.get('playOrder')
+		return int(play_order) if play_order else None
+
+	@play_order.setter
+	def play_order(self, value: int) -> None:
+		"""Set the playOrder attribute."""
+		self.element.set('playOrder', str(value))
+
+	@property
+	def nav_label(self) -> Optional[NCXNavLabel]:
+		"""Get the navLabel child element."""
+		nav_labels = self.element.xpath(
+			'./ncx:navLabel', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if nav_labels:
+			return NCXNavLabel(nav_labels[0])
+		return None
+
+	@property
+	def content(self) -> Optional[NCXContent]:
+		"""Get the content child element."""
+		content_elements = self.element.xpath(
+			'./ncx:content', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if content_elements:
+			return NCXContent(content_elements[0])
+		return None
+
+	@property
+	def label_text(self) -> str:
+		"""Get the text of the navLabel."""
+		nav_label = self.nav_label
+		return nav_label.text if nav_label else ''
+
+	@property
+	def content_src(self) -> str:
+		"""Get the src of the content element."""
+		content = self.content
+		return content.src if content else ''
+
+
+class NCXNavList(NCXElement):
+	"""Represents the navList element."""
+
+	@property
+	def nav_label(self) -> Optional[NCXNavLabel]:
+		"""Get the navLabel child element."""
+		nav_labels = self.element.xpath(
+			'./ncx:navLabel', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if nav_labels:
+			return NCXNavLabel(nav_labels[0])
+		return None
+
+	@property
+	def nav_targets(self) -> List[NCXNavTarget]:
+		"""Get all navTarget elements."""
+		nav_target_elements = self.element.xpath(
+			'./ncx:navTarget', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXNavTarget(target) for target in nav_target_elements]
+
+	def add_nav_target(
+		self, id: str, label_text: str, src: str, play_order: Optional[int] = None
+	) -> NCXNavTarget:
+		"""Add a navTarget element."""
+		nav_target_element = etree.SubElement(self.element, 'navTarget')
+		nav_target = NCXNavTarget(nav_target_element)
+		nav_target.id = id
+
+		if play_order is not None:
+			nav_target.play_order = play_order
+
+		# Add navLabel
+		nav_label_element = etree.SubElement(nav_target_element, 'navLabel')
+		nav_label = NCXNavLabel(nav_label_element)
+		nav_label.text = label_text
+
+		# Add content
+		content_element = etree.SubElement(nav_target_element, 'content')
+		content = NCXContent(content_element)
+		content.src = src
+
+		return nav_target
+
+	@property
+	def label_text(self) -> str:
+		"""Get the text of the navLabel."""
+		nav_label = self.nav_label
+		return nav_label.text if nav_label else ''
+
+
+class NCXDocument(NCXElement):
+	"""Represents the root ncx element."""
+
+	@property
+	def version(self) -> str:
+		"""Get the version attribute."""
+		return self.element.get('version', '')
+
+	@version.setter
+	def version(self, value: str) -> None:
+		"""Set the version attribute."""
+		self.element.set('version', value)
+
+	@property
+	def lang(self) -> str:
+		"""Get the xml:lang attribute."""
+		return self.element.get('{http://www.w3.org/XML/1998/namespace}lang', '')
+
+	@lang.setter
+	def lang(self, value: str) -> None:
+		"""Set the xml:lang attribute."""
+		self.element.set('{http://www.w3.org/XML/1998/namespace}lang', value)
+
+	@property
+	def head(self) -> Optional[NCXHead]:
+		"""Get the head element."""
+		head_elements = self.element.xpath(
+			'./ncx:head', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if head_elements:
+			return NCXHead(head_elements[0])
+		return None
+
+	@property
+	def doc_title(self) -> Optional[NCXDocTitle]:
+		"""Get the docTitle element."""
+		doc_title_elements = self.element.xpath(
+			'./ncx:docTitle', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if doc_title_elements:
+			return NCXDocTitle(doc_title_elements[0])
+		return None
+
+	@property
+	def doc_author(self) -> Optional[NCXDocAuthor]:
+		"""Get the docAuthor element."""
+		doc_author_elements = self.element.xpath(
+			'./ncx:docAuthor', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if doc_author_elements:
+			return NCXDocAuthor(doc_author_elements[0])
+		return None
+
+	@property
+	def nav_map(self) -> Optional[NCXNavMap]:
+		"""Get the navMap element."""
+		nav_map_elements = self.element.xpath(
+			'./ncx:navMap', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if nav_map_elements:
+			return NCXNavMap(nav_map_elements[0])
+		return None
+
+	@property
+	def page_list(self) -> Optional[NCXPageList]:
+		"""Get the pageList element."""
+		page_list_elements = self.element.xpath(
+			'./ncx:pageList', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		if page_list_elements:
+			return NCXPageList(page_list_elements[0])
+		return None
+
+	@property
+	def nav_lists(self) -> List[NCXNavList]:
+		"""Get all navList elements."""
+		nav_list_elements = self.element.xpath(
+			'./ncx:navList', namespaces={'ncx': 'http://www.daisy.org/z3986/2005/ncx/'}
+		)
+		return [NCXNavList(nav_list) for nav_list in nav_list_elements]
+
+	@property
+	def title(self) -> str:
+		"""Get the document title text."""
+		doc_title = self.doc_title
+		return doc_title.text if doc_title else ''
+
+	@property
+	def author(self) -> str:
+		"""Get the document author text."""
+		doc_author = self.doc_author
+		return doc_author.text if doc_author else ''
+
+	def get_uid(self) -> Optional[str]:
+		"""Get the dtb:uid meta content."""
+		head = self.head
+		if head:
+			uid_meta = head.get_meta('dtb:uid')
+			return uid_meta.content if uid_meta else None
+		return None
+
+	def get_depth(self) -> Optional[int]:
+		"""Get the dtb:depth meta content."""
+		head = self.head
+		if head:
+			depth_meta = head.get_meta('dtb:depth')
+			if depth_meta and depth_meta.content:
+				try:
+					return int(depth_meta.content)
+				except ValueError:
+					pass
+		return None
+
+	def get_total_page_count(self) -> Optional[int]:
+		"""Get the dtb:totalPageCount meta content."""
+		head = self.head
+		if head:
+			page_count_meta = head.get_meta('dtb:totalPageCount')
+			if page_count_meta and page_count_meta.content:
+				try:
+					return int(page_count_meta.content)
+				except ValueError:
+					pass
+		return None
+
+	def get_max_page_number(self) -> Optional[int]:
+		"""Get the dtb:maxPageNumber meta content."""
+		head = self.head
+		if head:
+			max_page_meta = head.get_meta('dtb:maxPageNumber')
+			if max_page_meta and max_page_meta.content:
+				try:
+					return int(max_page_meta.content)
+				except ValueError:
+					pass
+		return None

--- a/tests/test_ncx_dom.py
+++ b/tests/test_ncx_dom.py
@@ -1,0 +1,360 @@
+"""
+Tests for NCX DOM.
+"""
+
+from lxml import etree
+
+from epub_utils.navigation.ncx.dom import NCXDocument
+
+NCX_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en-US">
+    <head>
+        <meta name="dtb:uid" content="org-example-5059463624137734586"/>
+        <meta name="dtb:depth" content="2"/>
+        <meta name="dtb:totalPageCount" content="100"/>
+        <meta name="dtb:maxPageNumber" content="100"/>
+    </head>
+    <docTitle>
+        <text>Selections from "Great Pictures, As Seen and Described by Famous Writers"</text>
+    </docTitle>
+    <docAuthor>
+        <text>Esther Singleton</text>
+    </docAuthor>
+    <navMap>
+        <navPoint class="h1" id="ch1" playOrder="1">
+            <navLabel>
+                <text>Chapter 1</text>
+            </navLabel>
+            <content src="content.html#ch_1"/>
+            <navPoint class="h2" id="ch_1_1" playOrder="2">
+                <navLabel>
+                    <text>Chapter 1.1</text>
+                </navLabel>
+                <content src="content.html#ch_1_1"/>
+            </navPoint>
+        </navPoint>
+        <navPoint class="h1" id="ch2" playOrder="3">
+            <navLabel>
+                <text>Chapter 2</text>
+            </navLabel>
+            <content src="content.html#ch_2"/>
+        </navPoint>
+    </navMap>
+    <pageList>
+        <pageTarget id="p1" type="normal" value="1" playOrder="1">
+            <navLabel><text>1</text></navLabel>
+            <content src="content.html#p1"/>
+        </pageTarget>
+        <pageTarget id="p2" type="normal" value="2" playOrder="2">
+            <navLabel><text>2</text></navLabel>
+            <content src="content.html#p2"/>
+        </pageTarget>
+    </pageList>
+    <navList>
+        <navLabel>
+            <text>List of Illustrations</text>
+        </navLabel>
+        <navTarget id="ill-1">
+            <navLabel><text>Portrait of Georg Gisze (Holbein)</text></navLabel>
+            <content src="content.html#ill1"/>
+        </navTarget>
+        <navTarget id="ill-2">
+            <navLabel><text>The adoration of the lamb (Van Eyck)</text></navLabel>
+            <content src="content.html#ill2"/>
+        </navTarget>
+    </navList>
+</ncx>"""
+
+
+def test_ncx_document_parsing():
+	"""Test that NCXDocument correctly parses the XML string into DOM tree."""
+	# Parse the XML
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	# Test root element attributes
+	assert ncx_doc.version == '2005-1'
+	assert ncx_doc.lang == 'en-US'
+
+
+def test_ncx_document_head():
+	"""Test that the head element and its meta tags are correctly parsed."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	head = ncx_doc.head
+	assert head is not None
+
+	# Test meta elements
+	metas = head.metas
+	assert len(metas) == 4
+
+	# Test specific meta values
+	uid_meta = head.get_meta('dtb:uid')
+	assert uid_meta is not None
+	assert uid_meta.content == 'org-example-5059463624137734586'
+
+	depth_meta = head.get_meta('dtb:depth')
+	assert depth_meta is not None
+	assert depth_meta.content == '2'
+
+	page_count_meta = head.get_meta('dtb:totalPageCount')
+	assert page_count_meta is not None
+	assert page_count_meta.content == '100'
+
+	max_page_meta = head.get_meta('dtb:maxPageNumber')
+	assert max_page_meta is not None
+	assert max_page_meta.content == '100'
+
+
+def test_ncx_document_title_and_author():
+	"""Test that docTitle and docAuthor elements are correctly parsed."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	# Test document title
+	doc_title = ncx_doc.doc_title
+	assert doc_title is not None
+	assert (
+		doc_title.text
+		== 'Selections from "Great Pictures, As Seen and Described by Famous Writers"'
+	)
+	assert (
+		ncx_doc.title == 'Selections from "Great Pictures, As Seen and Described by Famous Writers"'
+	)
+
+	# Test document author
+	doc_author = ncx_doc.doc_author
+	assert doc_author is not None
+	assert doc_author.text == 'Esther Singleton'
+	assert ncx_doc.author == 'Esther Singleton'
+
+
+def test_ncx_document_nav_map():
+	"""Test that the navMap and navPoint elements are correctly parsed."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	nav_map = ncx_doc.nav_map
+	assert nav_map is not None
+
+	# Test top-level nav points
+	nav_points = nav_map.nav_points
+	assert len(nav_points) == 2
+
+	# Test first nav point (Chapter 1)
+	ch1 = nav_points[0]
+	assert ch1.id == 'ch1'
+	assert ch1.class_attr == 'h1'
+	assert ch1.play_order == 1
+	assert ch1.label_text == 'Chapter 1'
+	assert ch1.content_src == 'content.html#ch_1'
+
+	# Test nested nav point (Chapter 1.1)
+	ch1_children = ch1.nav_points
+	assert len(ch1_children) == 1
+	ch1_1 = ch1_children[0]
+	assert ch1_1.id == 'ch_1_1'
+	assert ch1_1.class_attr == 'h2'
+	assert ch1_1.play_order == 2
+	assert ch1_1.label_text == 'Chapter 1.1'
+	assert ch1_1.content_src == 'content.html#ch_1_1'
+
+	# Test second nav point (Chapter 2)
+	ch2 = nav_points[1]
+	assert ch2.id == 'ch2'
+	assert ch2.class_attr == 'h1'
+	assert ch2.play_order == 3
+	assert ch2.label_text == 'Chapter 2'
+	assert ch2.content_src == 'content.html#ch_2'
+
+	# Test that Chapter 2 has no children
+	assert len(ch2.nav_points) == 0
+
+	# Test get_all_nav_points method
+	all_nav_points = nav_map.get_all_nav_points()
+	assert len(all_nav_points) == 3  # ch1, ch_1_1, ch2
+
+
+def test_ncx_document_page_list():
+	"""Test that the pageList and pageTarget elements are correctly parsed."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	page_list = ncx_doc.page_list
+	assert page_list is not None
+
+	page_targets = page_list.page_targets
+	assert len(page_targets) == 2
+
+	# Test first page target
+	p1 = page_targets[0]
+	assert p1.id == 'p1'
+	assert p1.type_attr == 'normal'
+	assert p1.value == '1'
+	assert p1.play_order == 1
+	assert p1.label_text == '1'
+	assert p1.content_src == 'content.html#p1'
+
+	# Test second page target
+	p2 = page_targets[1]
+	assert p2.id == 'p2'
+	assert p2.type_attr == 'normal'
+	assert p2.value == '2'
+	assert p2.play_order == 2
+	assert p2.label_text == '2'
+	assert p2.content_src == 'content.html#p2'
+
+
+def test_ncx_document_nav_list():
+	"""Test that the navList and navTarget elements are correctly parsed."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	nav_lists = ncx_doc.nav_lists
+	assert len(nav_lists) == 1
+
+	nav_list = nav_lists[0]
+	assert nav_list.label_text == 'List of Illustrations'
+
+	nav_targets = nav_list.nav_targets
+	assert len(nav_targets) == 2
+
+	# Test first nav target
+	ill1 = nav_targets[0]
+	assert ill1.id == 'ill-1'
+	assert ill1.label_text == 'Portrait of Georg Gisze (Holbein)'
+	assert ill1.content_src == 'content.html#ill1'
+
+	# Test second nav target
+	ill2 = nav_targets[1]
+	assert ill2.id == 'ill-2'
+	assert ill2.label_text == 'The adoration of the lamb (Van Eyck)'
+	assert ill2.content_src == 'content.html#ill2'
+
+
+def test_ncx_document_convenience_methods():
+	"""Test the convenience methods for extracting metadata."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	# Test UID extraction
+	assert ncx_doc.get_uid() == 'org-example-5059463624137734586'
+
+	# Test depth extraction
+	assert ncx_doc.get_depth() == 2
+
+	# Test page count extraction
+	assert ncx_doc.get_total_page_count() == 100
+
+	# Test max page number extraction
+	assert ncx_doc.get_max_page_number() == 100
+
+
+def test_ncx_nav_label_content_access():
+	"""Test accessing navLabel and content elements directly."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	nav_map = ncx_doc.nav_map
+	nav_point = nav_map.nav_points[0]  # Chapter 1
+
+	# Test navLabel access
+	nav_label = nav_point.nav_label
+	assert nav_label is not None
+	text_element = nav_label.text_element
+	assert text_element is not None
+	assert text_element.text == 'Chapter 1'
+
+	# Test content access
+	content = nav_point.content
+	assert content is not None
+	assert content.src == 'content.html#ch_1'
+
+
+def test_ncx_document_with_minimal_xml():
+	"""Test NCXDocument with minimal valid NCX XML."""
+	minimal_ncx = """<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+    <head>
+        <meta name="dtb:uid" content="test-uid"/>
+    </head>
+    <docTitle>
+        <text>Test Book</text>
+    </docTitle>
+    <navMap>
+        <navPoint id="ch1" playOrder="1">
+            <navLabel>
+                <text>Chapter 1</text>
+            </navLabel>
+            <content src="ch1.html"/>
+        </navPoint>
+    </navMap>
+</ncx>"""
+
+	tree = etree.fromstring(minimal_ncx.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	# Test basic parsing
+	assert ncx_doc.version == '2005-1'
+	assert ncx_doc.title == 'Test Book'
+	assert ncx_doc.get_uid() == 'test-uid'
+
+	# Test nav map
+	nav_map = ncx_doc.nav_map
+	assert nav_map is not None
+	nav_points = nav_map.nav_points
+	assert len(nav_points) == 1
+	assert nav_points[0].label_text == 'Chapter 1'
+
+	# Test optional elements are None when not present
+	assert ncx_doc.doc_author is None
+	assert ncx_doc.author == ''
+	assert ncx_doc.page_list is None
+	assert len(ncx_doc.nav_lists) == 0
+
+
+def test_ncx_element_attribute_access():
+	"""Test getting and setting attributes on NCX elements."""
+	tree = etree.fromstring(NCX_XML.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	nav_point = ncx_doc.nav_map.nav_points[0]
+
+	# Test getting attributes
+	assert nav_point.get_attribute('id') == 'ch1'
+	assert nav_point.get_attribute('class') == 'h1'
+	assert nav_point.get_attribute('playOrder') == '1'
+	assert nav_point.get_attribute('nonexistent') is None
+
+	# Test setting attributes
+	nav_point.set_attribute('custom-attr', 'test-value')
+	assert nav_point.get_attribute('custom-attr') == 'test-value'
+
+
+def test_ncx_document_missing_elements():
+	"""Test behavior when optional elements are missing."""
+	minimal_ncx = """<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+    <head>
+        <meta name="dtb:uid" content="test-uid"/>
+    </head>
+    <navMap>
+    </navMap>
+</ncx>"""
+
+	tree = etree.fromstring(minimal_ncx.encode('utf-8'))
+	ncx_doc = NCXDocument(tree)
+
+	# Test missing elements return None or empty values
+	assert ncx_doc.doc_title is None
+	assert ncx_doc.title == ''
+	assert ncx_doc.doc_author is None
+	assert ncx_doc.author == ''
+	assert ncx_doc.page_list is None
+	assert len(ncx_doc.nav_lists) == 0
+
+	# Test missing meta elements return None
+	assert ncx_doc.get_depth() is None
+	assert ncx_doc.get_total_page_count() is None
+	assert ncx_doc.get_max_page_number() is None

--- a/tests/test_ncx_navigation.py
+++ b/tests/test_ncx_navigation.py
@@ -1,0 +1,35 @@
+from epub_utils.navigation.ncx import NCXNavigation
+
+NCX_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en">
+    <head>
+        <meta name="dtb:uid" content="urn:uuid:12345"/>
+        <meta name="dtb:depth" content="1"/>
+        <meta name="dtb:totalPageCount" content="0"/>
+        <meta name="dtb:maxPageNumber" content="0"/>
+    </head>
+    <docTitle>
+        <text>Sample Book</text>
+    </docTitle>
+    <navMap>
+        <navPoint id="navpoint-1" playOrder="1">
+            <navLabel>
+                <text>Chapter 1</text>
+            </navLabel>
+            <content src="chapter1.xhtml"/>
+        </navPoint>
+    </navMap>
+</ncx>"""
+
+
+def test_ncx_navigation_initialization():
+	"""Test that the NCXNavigation class initializes correctly."""
+	ncx = NCXNavigation(NCX_XML, 'application/x-dtbncx+xml', 'toc.ncx')
+	assert ncx is not None
+	assert ncx.xml_content == NCX_XML
+	assert ncx.media_type == 'application/x-dtbncx+xml'
+	assert ncx.href == 'toc.ncx'
+
+	assert ncx.xmlns == 'http://www.daisy.org/z3986/2005/ncx/'
+	assert ncx.version == '2005-1'
+	assert ncx.lang == 'en'


### PR DESCRIPTION
This PR:
- Adds comprehensive navigation support for the OPF 2.0 defined Navigation Control file for XML applications (NCX).
    - __NOTES__: due to different archive layouts, I've found important to move navigation parsing to format-specific classes that make reading and (later on) manipulation easier. 